### PR TITLE
Quality improvements in: conn, decodeControl, Entry and EntryAttribute 

### DIFF
--- a/add_test.go
+++ b/add_test.go
@@ -109,5 +109,4 @@ func TestAttribute_decode(t *testing.T) {
 			assert.NotNil(got)
 		})
 	}
-
 }

--- a/conn.go
+++ b/conn.go
@@ -177,8 +177,8 @@ func (c *conn) readPacket(requestID int) (*packet, error) {
 
 func (c *conn) initConn(netConn net.Conn) error {
 	const op = "gldap.(Conn).initConn"
-	if c == nil {
-		return fmt.Errorf("%s: missing connection: %w", op, ErrInvalidParameter)
+	if netConn == nil {
+		return fmt.Errorf("%s: missing net conn: %w", op, ErrInvalidParameter)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/conn.go
+++ b/conn.go
@@ -35,6 +35,9 @@ type conn struct {
 // to serve requests to an ldap client.
 func newConn(shutdownCtx context.Context, connID int, netConn net.Conn, logger hclog.Logger, router *Mux) (*conn, error) {
 	const op = "gldap.NewConn"
+	if shutdownCtx == nil {
+		return nil, fmt.Errorf("%s: missing shutdown context: %w", op, ErrInvalidParameter)
+	}
 	if connID == 0 {
 		return nil, fmt.Errorf("%s: missing connection id: %w", op, ErrInvalidParameter)
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,3 +1,114 @@
+package gldap
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_newConn(t *testing.T) {
+	testCtx := context.Background()
+
+	server, client := net.Pipe()
+	t.Cleanup(func() { server.Close(); client.Close() })
+
+	var buf bytes.Buffer
+	testLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   "test",
+		Output: &buf,
+	})
+
+	tests := map[string]struct {
+		ctx             context.Context
+		id              int
+		netConn         net.Conn
+		logger          hclog.Logger
+		router          *Mux
+		want            *conn
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		"missing-ctx": {
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing shutdown context",
+		},
+		"missing-id": {
+			ctx:             testCtx,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing connection id",
+		},
+		"missing-conn": {
+			ctx:             testCtx,
+			id:              1,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing connection",
+		},
+		"missing-logger": {
+			ctx:             testCtx,
+			id:              1,
+			netConn:         server,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing logger",
+		},
+		"missing-router": {
+			ctx:             testCtx,
+			id:              1,
+			netConn:         server,
+			logger:          testLogger,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing router",
+		},
+		"success": {
+			ctx:     testCtx,
+			id:      1,
+			netConn: server,
+			logger:  testLogger,
+			router:  &Mux{},
+			want: &conn{
+				shutdownCtx: testCtx,
+				connID:      1,
+				netConn:     server,
+				logger:      testLogger,
+				router:      &Mux{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := newConn(tc.ctx, tc.id, tc.netConn, tc.logger, tc.router)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(got)
+			assert.NotEmpty(got.reader)
+			assert.NotEmpty(got.writer)
+			tc.want.reader = got.reader
+			tc.want.writer = got.writer
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
 func Test_initConn(t *testing.T) {
 	server, client := net.Pipe()
 	t.Cleanup(func() { server.Close(); client.Close() })

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,41 @@
+func Test_initConn(t *testing.T) {
+	server, client := net.Pipe()
+	t.Cleanup(func() { server.Close(); client.Close() })
+	tests := map[string]struct {
+		c               *conn
+		netConn         net.Conn
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		"missing-conn": {
+			c:               &conn{},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing net conn",
+		},
+		"success": {
+			c:       &conn{},
+			netConn: server,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tc.c.initConn(tc.netConn)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotEmpty(tc.c.reader)
+			assert.NotEmpty(tc.c.writer)
+		})
+	}
+}

--- a/control.go
+++ b/control.go
@@ -90,6 +90,9 @@ func decodeControl(packet *ber.Packet) (Control, error) {
 		Criticality = false
 		value       *ber.Packet
 	)
+	if packet == nil {
+		return nil, fmt.Errorf("%s: packet is nil: %w", op, ErrInvalidParameter)
+	}
 
 	switch len(packet.Children) {
 	case 0:
@@ -143,6 +146,9 @@ func decodeControl(packet *ber.Packet) (Control, error) {
 			value.Value = nil
 			value.AppendChild(valueChildren)
 		}
+		if len(value.Children) < 1 {
+			return nil, fmt.Errorf("%s: paging control value must have a least 1 child: %w", op, ErrInvalidParameter)
+		}
 		value = value.Children[0]
 		value.Description = "Search Control Value"
 		value.Children[0].Description = "Paging Size"
@@ -172,6 +178,9 @@ func decodeControl(packet *ber.Packet) (Control, error) {
 			value.Data.Truncate(0)
 			value.Value = nil
 			value.AppendChild(valueChildren)
+		}
+		if len(value.Children) == 0 {
+			return nil, fmt.Errorf("%s: behera control value must have a least 1 child: %w", op, ErrInvalidParameter)
 		}
 
 		sequence := value.Children[0]
@@ -650,6 +659,10 @@ func NewControlPaging(pagingSize uint32, _ ...Option) (*ControlPaging, error) {
 }
 
 func addControlDescriptions(packet *ber.Packet) error {
+	const op = "gldap.addControlDescriptions"
+	if packet == nil {
+		return fmt.Errorf("%s: missing packet: %w", op, ErrInvalidParameter)
+	}
 	packet.Description = "Controls"
 	for _, child := range packet.Children {
 		var value *ber.Packet
@@ -658,7 +671,7 @@ func addControlDescriptions(packet *ber.Packet) error {
 		switch len(child.Children) {
 		case 0:
 			// at least one child is required for control type
-			return fmt.Errorf("at least one child is required for control type")
+			return fmt.Errorf("at least one child is required for a control type")
 
 		case 1:
 			// just type, no criticality or value

--- a/entry.go
+++ b/entry.go
@@ -2,6 +2,7 @@ package gldap
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -46,17 +47,27 @@ func NewEntry(dn string, attributes map[string][]string) *Entry {
 	}
 }
 
-// PrettyPrint outputs a human-readable description indenting
-func (e *Entry) PrettyPrint(indent int) {
-	fmt.Printf("%sDN: %s\n", strings.Repeat(" ", indent), e.DN)
+// PrettyPrint outputs a human-readable description indenting.  Supported
+// options: WithWriter
+func (e *Entry) PrettyPrint(indent int, opt ...Option) {
+	opts := getGeneralOpts(opt...)
+	if opts.withWriter == nil {
+		opts.withWriter = os.Stdout
+	}
+	fmt.Fprintf(opts.withWriter, "%sDN: %s\n", strings.Repeat(" ", indent), e.DN)
 	for _, attr := range e.Attributes {
-		attr.PrettyPrint(indent + 2)
+		attr.PrettyPrint(indent+2, opt...)
 	}
 }
 
-// PrettyPrint outputs a human-readable description with indenting
-func (e *EntryAttribute) PrettyPrint(indent int) {
-	fmt.Printf("%s%s: %s\n", strings.Repeat(" ", indent), e.Name, e.Values)
+// PrettyPrint outputs a human-readable description with indenting.  Supported
+// options: WithWriter
+func (e *EntryAttribute) PrettyPrint(indent int, opt ...Option) {
+	opts := getGeneralOpts(opt...)
+	if opts.withWriter == nil {
+		opts.withWriter = os.Stdout
+	}
+	fmt.Fprintf(opts.withWriter, "%s%s: %s\n", strings.Repeat(" ", indent), e.Name, e.Values)
 }
 
 // EntryAttribute holds a single attribute

--- a/entry_test.go
+++ b/entry_test.go
@@ -1,0 +1,36 @@
+func TestEntry_PrettyPrint(t *testing.T) {
+	tests := []struct {
+		name   string
+		entry  *Entry
+		writer *strings.Builder
+		want   string
+	}{
+		{
+			name: "with-writer",
+			entry: &Entry{
+				DN: "uid=alice",
+				Attributes: []*EntryAttribute{
+					NewEntryAttribute("cn", []string{"alice"})},
+			},
+			writer: new(strings.Builder),
+			want:   " DN: uid=alice\n   cn: [alice]\n",
+		},
+		{
+			name: "stdout",
+			entry: &Entry{
+				DN: "uid=alice",
+				Attributes: []*EntryAttribute{
+					NewEntryAttribute("cn", []string{"alice"})},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			tc.entry.PrettyPrint(1, WithWriter(tc.writer))
+			if !isNil(tc.writer) {
+				assert.Equal(tc.want, tc.writer.String())
+			}
+		})
+	}
+}

--- a/entry_test.go
+++ b/entry_test.go
@@ -1,3 +1,69 @@
+package gldap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntry_GetAttributes(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *Entry
+		attr  string
+		want  []string
+	}{
+		{
+			name: "empty",
+			entry: &Entry{
+				Attributes: []*EntryAttribute{},
+			},
+			want: []string{},
+		},
+		{
+			name: "found",
+			entry: &Entry{
+				Attributes: []*EntryAttribute{
+					NewEntryAttribute("found", []string{"value1", "value2"}),
+				},
+			},
+			attr: "found",
+			want: []string{"value1", "value2"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := tc.entry.GetAttributeValues(tc.attr)
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestEntryAttribute_AddValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		attr   *EntryAttribute
+		values []string
+		want   *EntryAttribute
+	}{
+		{
+			name:   "simple",
+			attr:   NewEntryAttribute("simple", []string{"v1"}),
+			values: []string{"v2", "v3"},
+			want:   NewEntryAttribute("simple", []string{"v1", "v2", "v3"}),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			tc.attr.AddValue(tc.values...)
+			assert.Equal(tc.want, tc.attr)
+		})
+	}
+}
+
 func TestEntry_PrettyPrint(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/option.go
+++ b/option.go
@@ -1,5 +1,10 @@
 package gldap
 
+import (
+	"io"
+	"reflect"
+)
+
 // Option defines a common functional options type which can be used in a
 // variadic parameter pattern.
 type Option func(interface{})
@@ -13,4 +18,40 @@ func applyOpts(opts interface{}, opt ...Option) {
 		}
 		o(opts)
 	}
+}
+
+type generalOptions struct {
+	withWriter io.Writer
+}
+
+func generalDefaults() generalOptions {
+	return generalOptions{}
+}
+
+func getGeneralOpts(opt ...Option) generalOptions {
+	opts := generalDefaults()
+	applyOpts(&opts, opt...)
+	return opts
+}
+
+// WithWriter allows you to specify an optional writer.
+func WithWriter(w io.Writer) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*generalOptions); ok {
+			if !isNil(w) {
+				o.withWriter = w
+			}
+		}
+	}
+}
+
+func isNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		return reflect.ValueOf(i).IsNil()
+	}
+	return false
 }

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,76 @@
+package gldap
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getGeneralOpts(t *testing.T) {
+	testWriter := new(strings.Builder)
+
+	tests := []struct {
+		name string
+		opts []Option
+		want interface{}
+	}{
+		{
+			name: "nil-opt",
+			opts: []Option{nil},
+			want: generalDefaults(),
+		},
+		{
+			name: "simple",
+			opts: []Option{WithWriter(testWriter)},
+			want: generalOptions{
+				withWriter: testWriter,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			opts := getGeneralOpts(tc.opts...)
+			assert.Equal(tc.want, opts)
+		})
+	}
+}
+
+func Test_isNil(t *testing.T) {
+	var testWriter io.Writer
+	testWriter = new(strings.Builder)
+	tests := []struct {
+		name string
+		i    interface{}
+		want bool
+	}{
+		{
+			name: "nil",
+			want: true,
+		},
+		{
+			name: "not-nil",
+			i:    new(strings.Builder),
+			want: false,
+		},
+		{
+			name: "not-nil-interface",
+			i:    testWriter,
+			want: false,
+		},
+		{
+			name: "not-nil-struct",
+			i:    generalDefaults(),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := isNil(tc.i)
+			assert.Equal(tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR includes:

- fix: check netConn properly when initializing a conn
- fix: check the shutdown ctx when creating a new conn
- chore: remove extra blank line found with gofumpt
- fix: improve decodeControl(...) data validation
- feature: support WithWriter option for PrettyPrint
- tests: improve Entry/EntryAttribute unit tests