### PR TITLE
Jimlambrt onclose callback

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -93,7 +93,9 @@ func (c *conn) serveRequests() error {
 			if err := w.Write(resp); err != nil {
 				return fmt.Errorf("%s: %w", op, err)
 			}
-			c.netConn.SetReadDeadline(time.Now().Add(time.Millisecond))
+			if err := c.netConn.SetReadDeadline(time.Now().Add(time.Millisecond)); err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
 			return nil
 		default:
 			// need a default to fall through to rest of loop...
@@ -200,6 +202,8 @@ func (c *conn) initConn(netConn net.Conn) error {
 func (c *conn) close() error {
 	const op = "gldap.(Conn).close"
 	c.requestsWg.Wait()
-	c.netConn.Close()
+	if err := c.netConn.Close(); err != nil {
+		return fmt.Errorf("%s: error closing conn: %w", op, err)
+	}
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -17,7 +17,7 @@ import (
 
 // conn is a connection to an ldap client
 type conn struct {
-	mu sync.Mutex // mutext for the conn
+	mu sync.Mutex // mutex for the conn
 
 	connID      int
 	netConn     net.Conn

--- a/control_test.go
+++ b/control_test.go
@@ -150,7 +150,7 @@ func runAddControlDescriptions(t *testing.T, originalControl Control, childDescr
 	}
 
 	encodedControls := encodeControls([]Control{originalControl})
-	addControlDescriptions(encodedControls)
+	require.NoError(t, addControlDescriptions(encodedControls))
 	encodedPacket := encodedControls.Children[0]
 	if len(encodedPacket.Children) != len(childDescriptions) {
 		t.Errorf("%sinvalid number of children: %d != %d", header, len(encodedPacket.Children), len(childDescriptions))

--- a/message_options.go
+++ b/message_options.go
@@ -27,6 +27,10 @@ func withMinChildren(min int) Option {
 	}
 }
 
+// we'll see if we start using this again in the near future,
+// but for now ignore the warning
+//
+//nolint:unused
 func withLenChildren(len int) Option {
 	return func(o interface{}) {
 		if o, ok := o.(*messageOptions); ok {

--- a/mux_test.go
+++ b/mux_test.go
@@ -32,7 +32,7 @@ func TestMux_serve(t *testing.T) {
 			err = s.Run(fmt.Sprintf(":%d", port))
 			assert.NoError(err)
 		}()
-		defer s.Stop()
+		defer func() { require.NoError(s.Stop()) }()
 		for {
 			time.Sleep(100 * time.Nanosecond)
 			if s.Ready() {
@@ -59,18 +59,20 @@ func TestMux_serve(t *testing.T) {
 
 		mux, err := NewMux()
 		require.NoError(err)
-		mux.DefaultRoute(func(w *ResponseWriter, req *Request) {
+		err = mux.DefaultRoute(func(w *ResponseWriter, req *Request) {
 			resp := req.NewResponse(WithResponseCode(ResultUnwillingToPerform), WithDiagnosticMessage("default handler"))
 			_ = w.Write(resp)
 		})
-		s.Router(mux)
+		require.NoError(err)
+		err = s.Router(mux)
+		require.NoError(err)
 
 		port := freePort(t)
 		go func() {
 			err = s.Run(fmt.Sprintf(":%d", port))
 			assert.NoError(err)
 		}()
-		defer s.Stop()
+		defer func() { _ = s.Stop() }()
 		for {
 			time.Sleep(100 * time.Nanosecond)
 			if s.Ready() {

--- a/option_test.go
+++ b/option_test.go
@@ -1,7 +1,6 @@
 package gldap
 
 import (
-	"io"
 	"strings"
 	"testing"
 
@@ -39,8 +38,7 @@ func Test_getGeneralOpts(t *testing.T) {
 }
 
 func Test_isNil(t *testing.T) {
-	var testWriter io.Writer
-	testWriter = new(strings.Builder)
+	testWriter := new(strings.Builder)
 	tests := []struct {
 		name string
 		i    interface{}

--- a/packet.go
+++ b/packet.go
@@ -595,11 +595,8 @@ func (p *packet) Log(out io.Writer, indent int, printBytes bool) {
 }
 
 func (p *packet) deleteParameters() (string, []Control, error) {
-	const (
-		op = "gldap.(packet).deleteDN"
+	const op = "gldap.(packet).deleteDN"
 
-		childDN = 0
-	)
 	requestPacket, err := p.requestPacket()
 	if err != nil {
 		return "", nil, fmt.Errorf("%s: %w", op, err)

--- a/request.go
+++ b/request.go
@@ -122,7 +122,7 @@ func (r *Request) StartTLS(tlsconfig *tls.Config) error {
 // Supported options: WithResponseCode, WithApplicationCode,
 // WithDiagnosticMessage, WithMatchedDN
 func (r *Request) NewResponse(opt ...Option) *GeneralResponse {
-	const op = "gldap.NewResponse"
+	const op = "gldap.NewResponse" // nolint:unused
 	opts := getResponseOpts(opt...)
 	if opts.withResponseCode == nil {
 		opts.withResponseCode = intPtr(ResultUnwillingToPerform)
@@ -144,7 +144,7 @@ func (r *Request) NewResponse(opt ...Option) *GeneralResponse {
 // NewExtendedResponse creates a new extended response.
 // Supported options: WithResponseCode
 func (r *Request) NewExtendedResponse(opt ...Option) *ExtendedResponse {
-	const op = "gldap.NewExtendedResponse"
+	const op = "gldap.NewExtendedResponse" // nolint:unused
 	opts := getResponseOpts(opt...)
 	resp := &ExtendedResponse{
 		baseResponse: &baseResponse{
@@ -160,7 +160,7 @@ func (r *Request) NewExtendedResponse(opt ...Option) *ExtendedResponse {
 // NewBindResponse creates a new bind response.
 // Supported options: WithResponseCode
 func (r *Request) NewBindResponse(opt ...Option) *BindResponse {
-	const op = "gldap.NewBindResponse"
+	const op = "gldap.NewBindResponse" // nolint:unused
 	opts := getResponseOpts(opt...)
 	resp := &BindResponse{
 		baseResponse: &baseResponse{
@@ -190,7 +190,7 @@ func (r *Request) GetSimpleBindMessage() (*SimpleBindMessage, error) {
 //
 // Supported options: WithResponseCode
 func (r *Request) NewSearchDoneResponse(opt ...Option) *SearchResponseDone {
-	const op = "gldap.(Request).NewSearchDoneResponse"
+	const op = "gldap.(Request).NewSearchDoneResponse" // nolint:unused
 	opts := getResponseOpts(opt...)
 	resp := &SearchResponseDone{
 		baseResponse: &baseResponse{

--- a/response.go
+++ b/response.go
@@ -69,14 +69,14 @@ func (rw *ResponseWriter) Write(r Response) error {
 }
 
 func beginResponse(messageID int64) *ber.Packet {
-	const op = "gldap.beginResponse"
+	const op = "gldap.beginResponse" // nolint:unused
 	p := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
 	p.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, messageID, "MessageID"))
 	return p
 }
 
 func addOptionalResponseChildren(bindResponse *ber.Packet, opt ...Option) {
-	const op = "gldap.addOptionalResponseChildren"
+	const op = "gldap.addOptionalResponseChildren" // nolint:unused
 	opts := getResponseOpts(opt...)
 	bindResponse.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, opts.withMatchedDN, "matchedDN"))
 	bindResponse.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, opts.withDiagnosticMessage, "diagnosticMessage"))
@@ -172,7 +172,7 @@ type GeneralResponse struct {
 }
 
 func (r *GeneralResponse) packet() *packet {
-	const op = "gldap.(GeneralResponse).packet"
+	const op = "gldap.(GeneralResponse).packet" // nolint:unused
 	replyPacket := beginResponse(r.messageID)
 
 	// a new packet for the bind response
@@ -199,7 +199,7 @@ func (r *SearchResponseDone) SetControls(controls ...Control) {
 }
 
 func (r *SearchResponseDone) packet() *packet {
-	const op = "gldap.(SearchDoneResponse).packet"
+	const op = "gldap.(SearchDoneResponse).packet" // nolint:unused
 	replyPacket := beginResponse(r.messageID)
 
 	resultPacket := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationSearchResultDone, nil, ApplicationCodeMap[ApplicationSearchResultDone])
@@ -227,7 +227,7 @@ func (r *SearchResponseEntry) AddAttribute(name string, values []string) {
 }
 
 func (r *SearchResponseEntry) packet() *packet {
-	const op = "gldap.(SearchEntryResponse).packet"
+	const op = "gldap.(SearchEntryResponse).packet" // nolint:unused
 	replyPacket := beginResponse(r.messageID)
 
 	resultPacket := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationSearchResultEntry, nil, ApplicationCodeMap[ApplicationSearchResultEntry])

--- a/route.go
+++ b/route.go
@@ -9,7 +9,7 @@ type routeOperation string
 
 const (
 	// undefinedRouteOperation is an undefined operation.
-	undefinedRouteOperation routeOperation = ""
+	undefinedRouteOperation routeOperation = "" // nolint:unused
 
 	// bindRouteOperation is a route supporting the bind operation
 	bindRouteOperation routeOperation = "bind"
@@ -34,7 +34,7 @@ const (
 
 	// defaultRouteOperation is a default route which is used when there are no routes
 	// defined for a particular operation
-	defaultRouteOperation routeOperation = "noRoute"
+	defaultRouteOperation routeOperation = "noRoute" // nolint:unused
 )
 
 // HandlerFunc defines a function for handling an LDAP request.
@@ -162,10 +162,7 @@ func (r *extendedRoute) match(req *Request) bool {
 		return false
 	}
 	_, ok := req.message.(*ExtendedOperationMessage)
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }
 
 func (r *searchRoute) match(req *Request) bool {
@@ -179,10 +176,10 @@ func (r *searchRoute) match(req *Request) bool {
 	if !ok {
 		return false
 	}
-	if r.basedn != "" && strings.ToLower(searchMsg.BaseDN) != strings.ToLower(r.basedn) {
+	if r.basedn != "" && !strings.EqualFold(searchMsg.BaseDN, r.basedn) {
 		return false
 	}
-	if r.filter != "" && strings.ToLower(searchMsg.Filter) != strings.ToLower(r.filter) {
+	if r.filter != "" && !strings.EqualFold(searchMsg.Filter, r.filter) {
 		return false
 	}
 	if r.scope != 0 && searchMsg.Scope != r.scope {

--- a/server_options.go
+++ b/server_options.go
@@ -13,6 +13,7 @@ type configOptions struct {
 	withReadTimeout          time.Duration
 	withWriteTimeout         time.Duration
 	withDisablePanicRecovery bool
+	withOnClose              OnCloseHandler
 }
 
 func configDefaults() configOptions {
@@ -71,6 +72,22 @@ func WithDisablePanicRecovery() Option {
 	return func(o interface{}) {
 		if o, ok := o.(*configOptions); ok {
 			o.withDisablePanicRecovery = true
+		}
+	}
+}
+
+// OnCloseHandler defines a function for a "on close" callback handler.  See:
+// NewServer(...) and WithOnClose(...) option for more information
+type OnCloseHandler func(connectionID int)
+
+// WithOnClose defines a OnCloseHandler that the server will use as a callback
+// every time a connection to the server is closed.   This allows callers to
+// clean up resources for closed connections (using their ID to determine which
+// one to clean up)
+func WithOnClose(handler OnCloseHandler) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*configOptions); ok {
+			o.withOnClose = handler
 		}
 	}
 }

--- a/server_options_test.go
+++ b/server_options_test.go
@@ -2,6 +2,8 @@ package gldap
 
 import (
 	"crypto/tls"
+	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -54,4 +56,15 @@ func Test_WithDisablePanicRecovery(t *testing.T) {
 	testOpts := configDefaults()
 	testOpts.withDisablePanicRecovery = true
 	assert.Equal(opts, testOpts)
+}
+
+func Test_WitOnClose(t *testing.T) {
+	t.Parallel()
+	fn := func(int) {}
+	assert := assert.New(t)
+	opts := getConfigOpts(WithOnClose(fn))
+	testOpts := configDefaults()
+	testOpts.withOnClose = fn
+	assert.Equal(runtime.FuncForPC(reflect.ValueOf(opts.withOnClose).Pointer()).Name(),
+		runtime.FuncForPC(reflect.ValueOf(testOpts.withOnClose).Pointer()).Name())
 }

--- a/server_test.go
+++ b/server_test.go
@@ -84,7 +84,8 @@ func TestServer_Run(t *testing.T) {
 			port := testdirectory.FreePort(t)
 
 			go func() {
-				s.Run(fmt.Sprintf(":%d", port), tc.runOpts...)
+				err = s.Run(fmt.Sprintf(":%d", port), tc.runOpts...)
+				assert.NoError(err)
 			}()
 			t.Cleanup(func() { err := s.Stop(); assert.NoError(err) })
 			for {

--- a/testdirectory/directory_test.go
+++ b/testdirectory/directory_test.go
@@ -636,12 +636,6 @@ func TestDirectory_DeleteResponse(t *testing.T) {
 	td.SetUsers(users...)
 	td.SetGroups(groups)
 
-	const (
-		alice = 0
-		bob   = 1
-		eve   = 2
-	)
-
 	tests := []struct {
 		name            string
 		dn              string

--- a/testdirectory/testing.go
+++ b/testdirectory/testing.go
@@ -137,18 +137,20 @@ func GetTLSConfig(t TestingT, opt ...Option) (s *tls.Config, c *tls.Config) {
 	require.NoError(err)
 
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	err = pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
+	require.NoError(err)
 
 	privBytes, err := x509.MarshalPKCS8PrivateKey(caPriv)
 	require.NoError(err)
 	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
+	err = pem.Encode(caPrivKeyPEM, &pem.Block{
 		Type:  "PRIVATE KEY",
 		Bytes: privBytes,
 	})
+	require.NoError(err)
 
 	cert := &x509.Certificate{
 		SerialNumber:          genSerialNumber(t),
@@ -212,19 +214,21 @@ func genCert(t TestingT, ca *x509.Certificate, caPriv interface{}, certTemplate 
 	require.NoError(err)
 
 	certPEM := new(bytes.Buffer)
-	pem.Encode(certPEM, &pem.Block{
+	err = pem.Encode(certPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
 	})
+	require.NoError(err)
 
 	privBytes, err := x509.MarshalPKCS8PrivateKey(certPrivKey)
 	require.NoError(err)
 
 	certPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(certPrivKeyPEM, &pem.Block{
+	err = pem.Encode(certPrivKeyPEM, &pem.Block{
 		Type:  "PRIVATE KEY",
 		Bytes: privBytes,
 	})
+	require.NoError(err)
 
 	newCert, err := tls.X509KeyPair(certPEM.Bytes(), certPrivKeyPEM.Bytes())
 	require.NoError(err)

--- a/testing.go
+++ b/testing.go
@@ -212,8 +212,5 @@ func testControlPaging(t *testing.T, pagingSize uint32, opt ...Option) *ControlP
 // TestWithDebug specifies that the test should be run under "debug" mode
 func TestWithDebug(t *testing.T) bool {
 	t.Helper()
-	if strings.ToLower(os.Getenv("DEBUG")) == "true" {
-		return true
-	}
-	return false
+	return strings.ToLower(os.Getenv("DEBUG")) == "true"
 }


### PR DESCRIPTION
WithOnClose(...) allows callers to define an optional OnCloseHandler
that the server will use as a callback every time a connection to the
server is closed.   This allows callers to clean up resources for closed
connections (using the conn ID to determine which one to clean up)

Fixes https://github.com/jimlambrt/gldap/issues/37