### PR TITLE
feature: add ConvertString(...)

### DIFF
--- a/testdirectory/directory_test.go
+++ b/testdirectory/directory_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/hashicorp/go-hclog"
 	"github.com/jimlambrt/gldap"
@@ -374,7 +375,7 @@ func TestDirectory_ModifyResponse(t *testing.T) {
 				DN: users[alice].DN,
 				Attributes: func() []*gldap.EntryAttribute {
 					attrs := append([]*gldap.EntryAttribute{}, users[alice].Attributes...)
-					attrs = append(attrs, gldap.NewEntryAttribute("description", []string{"\x04\x12test-add-attribute"}))
+					attrs = append(attrs, gldap.NewEntryAttribute("description", []string{gldap.TestEncodeString(t, ber.TagOctetString, "test-add-attribute")}))
 					return attrs
 				}(),
 			},

--- a/testing.go
+++ b/testing.go
@@ -11,6 +11,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testOptions struct {
+	// test options
+	withDescription string
+}
+
+func testDefaults() testOptions {
+	return testOptions{}
+}
+
+func getTestOpts(opt ...Option) testOptions {
+	opts := testDefaults()
+	applyOpts(&opts, opt...)
+	return opts
+}
+
+// WithDescription allows you to specify an optional description.
+func WithDescription(desc string) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*testOptions); ok {
+			o.withDescription = desc
+		}
+	}
+}
+
 func freePort(t *testing.T) int {
 	t.Helper()
 	require := require.New(t)
@@ -213,4 +237,13 @@ func testControlPaging(t *testing.T, pagingSize uint32, opt ...Option) *ControlP
 func TestWithDebug(t *testing.T) bool {
 	t.Helper()
 	return strings.ToLower(os.Getenv("DEBUG")) == "true"
+}
+
+func TestEncodeString(t *testing.T, tag ber.Tag, s string, opt ...Option) string {
+	t.Helper()
+	opts := getTestOpts(opt...)
+	pkt := ber.NewString(ber.ClassUniversal, ber.TypePrimitive, tag, s, opts.withDescription)
+	dec, err := ber.DecodePacketErr(pkt.Bytes())
+	require.NoError(t, err)
+	return string(dec.Bytes())
 }

--- a/testing_e2e_test.go
+++ b/testing_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/hashicorp/go-hclog"
 	"github.com/jimlambrt/gldap"
@@ -351,7 +352,7 @@ func TestDirectory_ModifyResponse(t *testing.T) {
 				DN: users[alice].DN,
 				Attributes: func() []*gldap.EntryAttribute {
 					attrs := append([]*gldap.EntryAttribute{}, users[alice].Attributes...)
-					attrs = append(attrs, gldap.NewEntryAttribute("description", []string{"\x04\x12test-add-attribute"}))
+					attrs = append(attrs, gldap.NewEntryAttribute("description", []string{gldap.TestEncodeString(t, ber.TagOctetString, "test-add-attribute")}))
 					return attrs
 				}(),
 			},

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,0 +1,16 @@
+package gldap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WithDescription(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	opts := getTestOpts(WithDescription("desc"))
+	testOpts := testDefaults()
+	testOpts.withDescription = "desc"
+	assert.Equal(opts, testOpts)
+}


### PR DESCRIPTION
ConvertString will convert an ASN1 BER Octet string into a "native" go string.  Support ber string encoding types: OctetString, GeneralString and all other types will return an error.