### PR TITLE
fix: remove `matchedDN` and `diagnosticMessage` from `SearchResponseEntry`

### DIFF
--- a/response.go
+++ b/response.go
@@ -241,9 +241,6 @@ func (r *SearchResponseEntry) packet() *packet {
 	}
 	resultPacket.AppendChild(attributesPacket)
 
-	// Add optional diagnostic message and matched DN
-	addOptionalResponseChildren(resultPacket, WithDiagnosticMessage(r.diagMessage), WithMatchedDN(r.matchedDN))
-
 	replyPacket.AppendChild(resultPacket)
 	return &packet{Packet: replyPacket}
 }


### PR DESCRIPTION
Hi, 

Firstly, thanks for this library !!

This PR removes `matchedDN` and `diagnosticMessage` from `SearchEntryResponse` because they should not be found here.

> ```
> SearchResultEntry ::= [APPLICATION 4] SEQUENCE {
>      objectName      LDAPDN,
>      attributes      PartialAttributeList }
> 
> PartialAttributeList ::= SEQUENCE OF
>        partialAttribute PartialAttribute
> 
> LDAPDN ::= LDAPString
>            -- Constrained to  [RFC4514]
> 
> LDAPString ::= OCTET STRING -- UTF-8 encoded,
>               -- [ISO10646] characters
> 
> PartialAttribute ::= SEQUENCE {
>      type       AttributeDescription,
>      vals       SET OF value AttributeValue }
> 
> AttributeDescription ::= LDAPString
>            -- Constrained to
>            -- [RFC4512]
> 
> AttributeValue ::= OCTET STRING
> ```
> source: https://ldap.com/ldapv3-wire-protocol-reference-search/,
