### PR TITLE
tests: add missing calls to t.Helper()

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -51,10 +51,7 @@ func TestMux_serve(t *testing.T) {
 	})
 	t.Run("default-route", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
-		buf := &safeBuf{
-			mu:  &sync.Mutex{},
-			buf: &strings.Builder{},
-		}
+		buf := testSafeBuf(t)
 		testLogger := hclog.New(&hclog.LoggerOptions{
 			Name:   "TestServer_Run-logger",
 			Level:  hclog.Debug,


### PR DESCRIPTION
In a few places, we added calls t.Helper()
properly in test only funcs.

In the test safeBuf struct, we added support
for t.Helper() in all the receiver funcs